### PR TITLE
Change runout computation algorithm v2

### DIFF
--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -340,8 +340,10 @@ class FilamentSensorBase {
 
   typedef struct {
     float runout[NUM_RUNOUT_SENSORS];
+    bool runout_reset[NUM_RUNOUT_SENSORS]; // flag to reset runout later if it is not possible to reset now
     #if ENABLED(FILAMENT_SWITCH_AND_MOTION)
       float motion[NUM_MOTION_SENSORS];
+      bool motion_reset[NUM_MOTION_SENSORS]; // flag to reset motion later if it is not possible to reset now
     #endif
   } countdown_t;
 
@@ -389,32 +391,50 @@ class FilamentSensorBase {
       }
 
       static void filament_present(const uint8_t extruder) {
-        if (mm_countdown.runout[extruder]<runout_distance_mm) {
-          // reset runout only if it is smaller than runout_distance
+        if (mm_countdown.runout[extruder]<runout_distance_mm || did_pause_print) {
+          // reset runout only if it is smaller than runout_distance or printing is paused
           // on bowden systems retract may be larger than runout_distance_mm, so if retract was added,
-          // we should leave it in place, so unretract will not cause runout event
+          // we should leave it in place, or following unretract will cause runout event
           mm_countdown.runout[extruder] = runout_distance_mm;
+          mm_countdown.runout_reset[extruder] = false; // do not need delayed reset
+        } else {
+          // if runout is larger than runout distance, we cannot reset right now, as with bowden and retract distance larger then runout_distance_mm
+          // it will lead to negative runout right after unretract.
+          // But we can not ignore filament_present event, as after unretract runout will become smaller then runout_distance_mm
+          // and it should be resetted after that. So we activate flag to call delayed reset
+          mm_countdown.runout_reset[extruder] = true;
         }
       }
 
       #if ENABLED(FILAMENT_SWITCH_AND_MOTION)
         static void filament_motion_present(const uint8_t extruder) {
-          if (mm_countdown.motion[extruder]<runout_distance_mm) {
-            // same logic as filament_present function
+          // same logic as filament_present function
+          if (mm_countdown.motion[extruder]<runout_distance_mm || did_pause_print) {
             mm_countdown.motion[extruder] = runout_distance_mm;
+            mm_countdown.motion_reset[extruder] = false;
+          } else {
+            mm_countdown.motion_reset[extruder] = true;
           }
         }
       #endif
 
       static void block_completed(const block_t * const b) {
-        if (b->steps.e) { // execute calculation if there is any extruder movement
+        if (b->steps.e && (did_pause_print || printingIsActive())) {
+          // execute calculation if there is any extruder movement
+          // and if printer on pause or it is printing
           // there is no need to ignore retract/unretract movement as they compensate each other
           const uint8_t e = b->extruder;
           const int32_t steps = b->steps.e;
           const float mm = (b->direction_bits.e ? steps : -steps) * planner.mm_per_step[E_AXIS_N(e)];
-          if (e < NUM_RUNOUT_SENSORS) mm_countdown.runout[e] -= mm;
+          if (e < NUM_RUNOUT_SENSORS) {
+            mm_countdown.runout[e] -= mm;
+            if (mm_countdown.runout_reset[e]) filament_present(e); // if reset is pending, try to reset
+          }
           #if ENABLED(FILAMENT_SWITCH_AND_MOTION)
-            if (e < NUM_MOTION_SENSORS) mm_countdown.motion[e] -= mm;
+            if (e < NUM_MOTION_SENSORS) {
+              mm_countdown.motion[e] -= mm;
+              if (mm_countdown.motion_reset[e]) filament_motion_present(e); // if reset is pending, try to reset
+            }
           #endif
         }
       }


### PR DESCRIPTION
### Description

This patch is a variant of resolving issue #26061

The problem is not only with firmware retraction, but also with software retraction. While patch #26082 solve problem with classic retraction (when printhead is still while retracting) it cannot solve the problem with software wipe retraction, which is introduced in Super Slicer for example. Also there may accumalte computation error because of additional unretract compensation. All in all it is better to take into account all extruder movement to have accurate data.

This is a prototype of this approach. I have tested this on initial gcode retract_test_ps_464_fw.gcode and retract_test_ss_464_wipe_r06.gcode. And fixed some issues. And it is working alright.

I plan to create a working firmware with my preferred config to check how it works on real printing. For now this is a draft.

In this patch I added flags to reset `runout` variables after unretract motion. Also `motion` variables were changed the same way. But honestly I do not know what `motion` variables are for. But from code I see they work alike to `runout` variables, so I made the same editing for `motion` variables too.

The idea is, when we take into account retract and unretract motion we cannot reset runout anytime. If retract distance is larger then runout distance if we reset between retract and unretract it will lead to runout trigger right after unretract.
So we unable to reset immediately. Also we cannot ignore event, as when unretract compensate retract movement we see that runout distance is smaller and smaller over time, which may lead to runout event again. So we raise a flag to trigger filament reset after unretract movement. It will try to reset at every movement until it succeeds.

### Requirements

This requires filament motion sensor, or at least filament present sensor to test.

### Benefits

Filament motion sensor will correctly detect runout event with small runout distances and large retract distances. And Slicers which experiment with retract wiping will not cause problem.

### Related Issues

This should solve issue #26061